### PR TITLE
Fix Array type recognization

### DIFF
--- a/x2js.js
+++ b/x2js.js
@@ -540,7 +540,7 @@
 			if (element === undefined || element === null || element === '') {
 				result += serializeStartTag(element, elementName, attributes, true);
 			} else if (typeof element == 'object') {
-				if (element instanceof Array) {
+				if (Object.prototype.toString.call(element) === '[object Array]') {
 					result += serializeArray(element, elementName, attributes);
 				} else if (element instanceof Date) {
 					result += serializeStartTag(element, elementName, attributes, false);

--- a/x2js.js
+++ b/x2js.js
@@ -539,7 +539,7 @@
 
 			if (element === undefined || element === null || element === '') {
 				result += serializeStartTag(element, elementName, attributes, true);
-			} else if (element instanceof Object) {
+			} else if (typeof element == 'object') {
 				if (element instanceof Array) {
 					result += serializeArray(element, elementName, attributes);
 				} else if (element instanceof Date) {


### PR DESCRIPTION
I stumbled on a bug: on node.js, some arrays in a big json object where not recognized as such and translated as if they where strings. It seems that Array objects in different JS context do not share the Prototype, so instanceof doesn't always work in different iframes or in node.js.
[This article explains what happens.](http://perfectionkills.com/instanceof-considered-harmful-or-how-to-write-a-robust-isarray/)