### PR TITLE
Added selfClosingElements option

### DIFF
--- a/tests_js2xml.js
+++ b/tests_js2xml.js
@@ -33,6 +33,27 @@
 		assert.strictEqual(xml, expected);
 	});
 
+	QUnit.test('Element with attribute and selfClosingElements set to false', function (assert) {
+		var js = {
+			'document': {
+				'element': {
+					'_attribute': 'value'
+				}
+			}
+		};
+		var x = new X2JS({
+			'selfClosingElements': false
+		});
+		var xml = x.js2xml(js);
+
+		var expected = '<document>' +
+			'<element attribute="value"></element>' +
+			'</document>';
+
+		// Implementation does not guarantee formatting so the test is somewhat fragile.
+		assert.strictEqual(xml, expected);
+	});
+
 	QUnit.test('Element with attribute containing XML characters', function (assert) {
 		var js = {
 			'document': {
@@ -137,6 +158,26 @@
 		assert.strictEqual(xml, expected);
 	});
 
+	QUnit.test('Empty string as value with selfClosingElements set to false', function (assert) {
+		var js = {
+			'document': {
+				'elementU': ''
+			}
+		};
+		var x = new X2JS({
+			'selfClosingElements': false
+		});
+
+		var xml = x.js2xml(js);
+
+		var expected = '<document>' +
+			'<elementU></elementU>' +
+			'</document>';
+
+		// Implementation does not guarantee formatting so the test is somewhat fragile.
+		assert.strictEqual(xml, expected);
+	});
+
 	QUnit.test('Basic array', function (assert) {
 		var js = {
 			'document': {
@@ -170,6 +211,26 @@
 		var expected = '<document>' +
 			'<elementX />' +
 			'<elementX />' +
+			'</document>';
+
+		// Implementation does not guarantee formatting so the test is somewhat fragile.
+		assert.strictEqual(xml, expected);
+	});
+
+	QUnit.test('Array of empty strings with selfClosingElements set to false', function (assert) {
+		var js = {
+			'document': {
+				'elementX': ['', '']
+			}
+		};
+		var x = new X2JS({
+			'selfClosingElements': false
+		});
+		var xml = x.js2xml(js);
+
+		var expected = '<document>' +
+			'<elementX></elementX>' +
+			'<elementX></elementX>' +
 			'</document>';
 
 		// Implementation does not guarantee formatting so the test is somewhat fragile.

--- a/tests_js2xml.js
+++ b/tests_js2xml.js
@@ -54,6 +54,27 @@
 		assert.strictEqual(xml, expected);
 	});
 
+	QUnit.test('Element with attribute and selfClosingElements set to true', function (assert) {
+		var js = {
+			'document': {
+				'element': {
+					'_attribute': 'value'
+				}
+			}
+		};
+		var x = new X2JS({
+			'selfClosingElements': true
+		});
+		var xml = x.js2xml(js);
+
+		var expected = '<document>' +
+			'<element attribute="value" />' +
+			'</document>';
+
+		// Implementation does not guarantee formatting so the test is somewhat fragile.
+		assert.strictEqual(xml, expected);
+	});
+
 	QUnit.test('Element with attribute containing XML characters', function (assert) {
 		var js = {
 			'document': {

--- a/x2js.js
+++ b/x2js.js
@@ -117,6 +117,12 @@
 			if (config.attributePrefix === undefined) {
 				config.attributePrefix = "_";
 			}
+
+			// If true, empty elements will created as self closing elements (<element />)
+			// If false, empty elements will be created with start and end tags (<element></element>)
+			if (config.selfClosingElements === undefined) {
+				config.selfClosingElements = true;
+			}
 		}
 
 		function initRequiredPolyfills() {
@@ -537,7 +543,7 @@
 		function serializeJavaScriptObject(element, elementName, attributes) {
 			var result = "";
 
-			if (element === undefined || element === null || element === '') {
+			if (element === undefined || element === null || element === '' && config.selfClosingElements) {
 				result += serializeStartTag(element, elementName, attributes, true);
 			} else if (typeof element == 'object') {
 				if (Object.prototype.toString.call(element) === '[object Array]') {
@@ -552,8 +558,11 @@
 						result += serializeStartTag(element, elementName, attributes, false);
 						result += serializeJavaScriptObjectChildren(element);
 						result += serializeEndTag(element, elementName);
-					} else {
+					} else if (config.selfClosingElements) {
 						result += serializeStartTag(element, elementName, attributes, true);
+					} else {
+						result += serializeStartTag(element, elementName, attributes, false);
+						result += serializeEndTag(element, elementName);
 					}
 				}
 			} else {
@@ -677,7 +686,7 @@
 		this.xml2dom = function(xml) {
 			return parseXml(xml);
 		};
-			
+
 		// Transforms a DOM tree to JavaScript objects.
 		this.dom2js = function dom2js(domNode) {
 			return deserializeDomChildren(domNode, null);

--- a/x2js.js
+++ b/x2js.js
@@ -543,7 +543,7 @@
 		function serializeJavaScriptObject(element, elementName, attributes) {
 			var result = "";
 
-			if (element === undefined || element === null || element === '' && config.selfClosingElements) {
+			if ((element === undefined || element === null || element === '') && config.selfClosingElements) {
 				result += serializeStartTag(element, elementName, attributes, true);
 			} else if (typeof element == 'object') {
 				if (Object.prototype.toString.call(element) === '[object Array]') {


### PR DESCRIPTION
Need to create XML for a legacy system which does not support self closing elements `<element />`.
If selfClosingElements option is set to false (defaults to true) `<element></element>` will be created instead of `<element />`.