### PR TITLE
Add config.keepCData to remove useless __cdata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "x2js",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "description": "Transforms between XML string and JavaScript object trees.",
     "main": "x2js.js",
     "dependencies": {

--- a/tests_xml2js.js
+++ b/tests_xml2js.js
@@ -21,6 +21,7 @@
 			'<elementX />' +
 			'<elementY>hello there</elementY>' +
 			'<elementZ><![CDATA[hello again]]></elementZ>' +
+			'<elementZA>Test<![CDATA[ hello again]]></elementZA>' +
 			'</document>';
 		var x = new X2JS();
 		var js = x.xml2js(xml);
@@ -38,9 +39,15 @@
 
 		assert.ok(js.document.elementY);
 		assert.strictEqual(js.document.elementY.toString(), 'hello there');
+		assert.strictEqual(js.document.elementY, 'hello there');
 
 		assert.ok(js.document.elementZ);
 		assert.strictEqual(js.document.elementZ.toString(), 'hello again');
+		assert.strictEqual(js.document.elementZ, 'hello again');
+
+		assert.ok(js.document.elementZA);
+		assert.strictEqual(js.document.elementZA.toString(), 'Test hello again');
+		assert.strictEqual(js.document.elementZA.__cdata, ' hello again');
 	});
 
 	QUnit.test('XML with namespace prefixes', function (assert) {

--- a/x2js.js
+++ b/x2js.js
@@ -124,7 +124,7 @@
 				config.selfClosingElements = true;
 			}
 
-			// If this property defined as false and an XML element has CData node, it will be converted to text without additional property "__cdata"
+			// If this property defined as false and an XML element has CData node ONLY, it will be converted to text without additional property "__cdata"
 			if (config.keepCData === undefined) {
 				config.keepCData = false;
 			}
@@ -404,8 +404,8 @@
 			}
 			delete result.__cnt;
 			
-			if (!config.keepCDada && (result.hasOwnProperty('__text') || result.hasOwnProperty('__cdata'))) {
-				return (result.__text ? result.__text : '') + (result.__cdata ? result.__cdata : '');
+			if (!config.keepCDada && (!result.hasOwnProperty('__text') && result.hasOwnProperty('__cdata'))) {
+				return (result.__cdata ? result.__cdata : '');
 			}
 
 			if (config.enableToStringFunc && (result.__text || result.__cdata)) {

--- a/x2js.js
+++ b/x2js.js
@@ -123,6 +123,11 @@
 			if (config.selfClosingElements === undefined) {
 				config.selfClosingElements = true;
 			}
+
+			// If this property defined as false and an XML element has CData node, it will be converted to text without additional property "__cdata"
+			if (config.keepCData === undefined) {
+				config.keepCData = false;
+			}
 		}
 
 		function initRequiredPolyfills() {
@@ -380,7 +385,7 @@
 				result.__text = convertToDateIfRequired(result.__text, "#text", elementPath + ".#text");
 			}
 
-			if (result["#cdata-section"]) {
+			if(result.hasOwnProperty('#cdata-section')) {
 				result.__cdata = result["#cdata-section"];
 				delete result["#cdata-section"];
 
@@ -398,6 +403,10 @@
 				}
 			}
 			delete result.__cnt;
+			
+			if (!config.keepCDada && (result.hasOwnProperty('__text') || result.hasOwnProperty('__cdata'))) {
+				return (result.__text ? result.__text : '') + (result.__cdata ? result.__cdata : '');
+			}
 
 			if (config.enableToStringFunc && (result.__text || result.__cdata)) {
 				result.toString = function toString() {


### PR DESCRIPTION
Hi !
I added `config.keepCData` to remove `__cdata` property when there is no text next to it.

I think sometimes the `toString()` method isn't needed, and it's easier to access directly on property.
I also update the unit tests. 

Could you check it ? :)
Regards, 
Maxime F.