### PR TITLE
fix IE 11 breaking down TEXT_NODE in multiple parts when they contain hyphens

### DIFF
--- a/x2js.js
+++ b/x2js.js
@@ -643,8 +643,24 @@
 				domNode.async = "false";
 				domNode.loadXML(xml);
 			}
-
+			
+			normalize(domNode);
+			
 			return domNode;
+		}
+
+		function normalize (node) {
+			// See http://stackoverflow.com/questions/22337498/why-does-ie11-handle-node-normalize-incorrectly-for-the-minus-symbol
+			if (!node) { return; }
+			if (node.nodeType == 3) {
+				while (node.nextSibling && node.nextSibling.nodeType == 3) {
+					node.nodeValue += node.nextSibling.nodeValue;
+					node.parentNode.removeChild(node.nextSibling);
+				}
+			} else {
+				normalize(node.firstChild);
+			}
+			normalize(node.nextSibling);
 		}
 
 		this.asArray = function asArray(prop) {


### PR DESCRIPTION
Also see
http://stackoverflow.com/questions/22337498/why-does-ie11-handle-node-normalize-incorrectly-for-the-minus-symbol
and
https://connect.microsoft.com/IE/feedback/details/1398926/ie11-does-not-parse-cdata-containing-hyphens-correctly
and
https://developer.mozilla.org/en-US/docs/Web/API/Node/normalize