### PR TITLE
fixed case for when a text node contains the number 0

### DIFF
--- a/x2js.js
+++ b/x2js.js
@@ -527,7 +527,7 @@
 
 			if (textNode instanceof Object) {
 				result += serializeComplexTextNodeContents(textNode);
-			} else if (textNode) {
+			} else if (textNode !== null) {
 				if (config.escapeMode)
 					result += escapeXmlChars(textNode);
 				else


### PR DESCRIPTION
Hi,

I encountered an issue where performing js2xml on a json object with a value of 0 would return an empty xml element. eg.

```

  var wrap = {
        age: 0
      };
  var data = x2js.js2xml(wrap);
  return data;
  //returns <age></age>


```

This is due to the 0 value not getting past the if statement in line 530 `if (textNode)` 

Changing this line to check if it's null returns `<age>0</age>` which I think is more correct. Please check and merge if it passes all your tests!
