### PR TITLE
Fix types definitions

### DIFF
--- a/x2js.d.ts
+++ b/x2js.d.ts
@@ -1,56 +1,56 @@
 /**
  * Transforms between XML string and JavaScript object trees.
- * 
+ *
  * @class X2JS
  */
-declare class X2JS {
-    
+export declare class X2JS {
+
     /**
      * Creates an instance of X2JS.
-     * 
+     *
      * @param {X2JS.Options} [config]
-     * 
+     *
      * @memberOf X2JS
      */
     constructor(config?: X2JS.Options);
 
     /**
      * Converts the provided property into an array. If the property is already an Array then it will return unchanged.
-     * 
+     *
      * @template T
      * @param {(T | Array<T>)} prop
      * @returns {Array<T>}
-     * 
+     *
      * @memberOf X2JS
      */
     asArray<T>(prop: T | Array<T>): Array<T>;
 
     /**
      * Converts the provided date value to a valid XML string.
-     * 
+     *
      * @param {(Date | number)} dt
      * @returns {string}
-     * 
+     *
      * @memberOf X2JS
      */
     toXmlDateTime(dt: Date | number): string;
 
     /**
      * Converts the provided date string into a javascript Date instance.
-     * 
+     *
      * @param {string} prop
      * @returns {Date}
-     * 
+     *
      * @memberOf X2JS
      */
     asDateTime(prop: string): Date;
 
     /**
      * Transformns an XML string into DOM-tree
-     * 
+     *
      * @param {string} xml
      * @returns {Node}
-     * 
+     *
      * @memberOf X2JS
      */
     xml2dom(xml: string): Document;
@@ -58,53 +58,53 @@ declare class X2JS {
 
     /**
      * Transforms a DOM tree to JavaScript objects.
-     * 
+     *
      * @template T
      * @param {Node} domNode
      * @returns {T}
-     * 
+     *
      * @memberOf X2JS
      */
     dom2js<T>(domNode: Document): T;
 
     /**
-     * 
-     * 
+     *
+     *
      * @template T
      * @param {T} jsObject
      * @returns {Node}
-     * 
+     *
      * @memberOf X2JS
      */
     js2dom<T>(jsObject: T): Document;
 
     /**
      * Transformns an XML string into JavaScript objects.
-     * 
+     *
      * @template T
      * @param {string} xml
      * @returns {T}
-     * 
+     *
      * @memberOf X2JS
      */
     xml2js<T>(xml: string): T;
 
     /**
      * Transforms JavaScript objects into an XML string.
-     * 
+     *
      * @template T
      * @param {T} json
      * @returns {string}
-     * 
+     *
      * @memberOf X2JS
      */
     js2xml<T>(json: T): string;
 
     /**
-     * Gets the current version of x2js. 
-     * 
+     * Gets the current version of x2js.
+     *
      * @returns {string}
-     * 
+     *
      * @memberOf X2JS
      */
     getVersion(): string;
@@ -114,7 +114,7 @@ declare namespace X2JS {
     export interface Options {
         /**
          * If set to "property" then <element>_asArray will be created to allow you to access any element as an array (even if there is only one of it).
-         * 
+         *
          * @type {('property' | 'none')}
          * @memberOf X2JS.Options
          */
@@ -122,7 +122,7 @@ declare namespace X2JS {
 
         /**
          * If "text" then <empty></empty> will be transformed to "". If "object" then <empty></empty> will be transformed to {}.
-         * 
+         *
          * @type {('object' | 'text')}
          * @memberOf X2JS.Options
          */
@@ -130,7 +130,7 @@ declare namespace X2JS {
 
         /**
          * Allows attribute values to be converted on the fly during parsing to objects.
-         * 
+         *
          * @type {Array<X2JS.AttributeConverter>}
          * @memberOf X2JS.Options
          */
@@ -138,7 +138,7 @@ declare namespace X2JS {
 
         /**
          * Any elements that match the paths here will have their text parsed as an XML datetime value (2011-11-12T13:00:00-07:00 style). The path can be a plain string (parent.child1.child2), a regex (/.*\.child2/) or function(elementPath).
-         * 
+         *
          * @type {(Array<string | RegExp | ((elementPath: string) => boolean)>)}
          * @memberOf X2JS.Options
          */
@@ -146,7 +146,7 @@ declare namespace X2JS {
 
         /**
          * Any elements that match the paths listed here will be stored in JavaScript objects as arrays even if there is only one of them. The path can be a plain string (parent.child1.child2), a regex (/.*\.child2/) or function(elementName, elementPath).
-         * 
+         *
          * @type {(Array<string | RegExp | ((elementName: string, elementPath: string) => boolean)>)}
          * @memberOf X2JS.Options
          */
@@ -154,7 +154,7 @@ declare namespace X2JS {
 
         /**
          * If true, a toString function is generated to print nodes containing text or cdata. Useful if you want to accept both plain text and CData as equivalent inputs.
-         * 
+         *
          * @type {boolean}
          * @memberOf X2JS.Options
          */
@@ -162,7 +162,7 @@ declare namespace X2JS {
 
         /**
          * If true, empty text tags are ignored for elements with child nodes.
-         * 
+         *
          * @type {boolean}
          * @memberOf X2JS.Options
          */
@@ -170,15 +170,15 @@ declare namespace X2JS {
 
         /**
          * If true, whitespace is trimmed from text nodes.
-         * 
+         *
          * @type {boolean}
          * @memberOf X2JS.Options
          */
         stripWhitespaces?: boolean;
 
         /**
-         * If true, double quotes are used in generated XML. 
-         * 
+         * If true, double quotes are used in generated XML.
+         *
          * @type {boolean}
          * @memberOf X2JS.Options
          */
@@ -186,7 +186,7 @@ declare namespace X2JS {
 
         /**
          * If true, the root element of the XML document is ignored when converting to objects. The result will directly have the root element's children as its own properties.
-         * 
+         *
          * @type {boolean}
          * @memberOf X2JS.Options
          */
@@ -194,15 +194,15 @@ declare namespace X2JS {
 
         /**
          * Whether XML characters in text are escaped when reading/writing XML.
-         * 
+         *
          * @type {boolean}
          * @memberOf X2JS.Options
          */
         escapeMode?: boolean;
 
         /**
-         * Prefix to use for properties that are created to represent XML attributes. 
-         * 
+         * Prefix to use for properties that are created to represent XML attributes.
+         *
          * @type {string}
          * @memberOf X2JS.Options
          */
@@ -210,7 +210,7 @@ declare namespace X2JS {
 
         /**
          * If true, empty elements will created as self closing elements (<element />). If false, empty elements will be created with start and end tags (<element></element>).
-         * 
+         *
          * @type {boolean}
          * @memberOf X2JS.Options
          */
@@ -218,7 +218,7 @@ declare namespace X2JS {
 
         /**
          * If this property defined as false and an XML element has CData node ONLY, it will be converted to text without additional property "__cdata".
-         * 
+         *
          * @type {boolean}
          * @memberOf X2JS.Options
          */
@@ -228,26 +228,26 @@ declare namespace X2JS {
     export interface AttributeConverter {
         /**
          * Indicates whether an attribute should be converted.
-         * 
+         *
          * @param {string} name
          * @param {*} value
          * @returns {boolean}
-         * 
+         *
          * @memberOf X2JS.AttributeConverter
          */
         test(name: string, value: any): boolean;
 
         /**
          * Will be called for every attribute where test() returns true, replacing the original value of the attribute.
-         * 
+         *
          * @param {string} name
          * @param {*} value
          * @returns {string}
-         * 
+         *
          * @memberOf X2JS.AttributeConverter
          */
         convert(name: string, value: any): string;
     }
 }
 
-export default X2JS;
+export as namespace X2JS;

--- a/x2js.js
+++ b/x2js.js
@@ -36,7 +36,9 @@
 	/* global define */
     if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
-        define([], factory);
+        define([], {
+			X2JS: factory()
+		});
     } else if (typeof module === 'object' && module.exports) {
         // Node. Does not work with strict CommonJS, but only CommonJS-like
 		// environments that support module.exports, like Node.

--- a/x2js.js
+++ b/x2js.js
@@ -37,7 +37,7 @@
     if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
         define([], {
-            X2JS: factory()
+            'X2JS': factory()
         });
     } else if (typeof module === 'object' && module.exports) {
         // Node. Does not work with strict CommonJS, but only CommonJS-like

--- a/x2js.js
+++ b/x2js.js
@@ -37,8 +37,8 @@
     if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
         define([], {
-			X2JS: factory()
-		});
+            X2JS: factory()
+        });
     } else if (typeof module === 'object' && module.exports) {
         // Node. Does not work with strict CommonJS, but only CommonJS-like
 		// environments that support module.exports, like Node.


### PR DESCRIPTION
I had a problem with import x2js in my typescript application. Now it works but this fix comes with compatibility breaking change

Now it works:
```typescript
import {X2JS} from 'x2js/x2js';
let x2js: X2JS = new X2JS();
let obj: any = x2js.xml2js(xml);
```